### PR TITLE
Reduce the security threshold of Gemini

### DIFF
--- a/bot/gemini/google_gemini_bot.py
+++ b/bot/gemini/google_gemini_bot.py
@@ -14,7 +14,7 @@ from bridge.reply import Reply, ReplyType
 from common.log import logger
 from config import conf
 from bot.baidu.baidu_wenxin_session import BaiduWenxinSession
-
+from google.generativeai.types import HarmCategory, HarmBlockThreshold
 
 # OpenAI对话模型API (可用)
 class GoogleGeminiBot(Bot):
@@ -38,15 +38,40 @@ class GoogleGeminiBot(Bot):
             gemini_messages = self._convert_to_gemini_messages(self.filter_messages(session.messages))
             genai.configure(api_key=self.api_key)
             model = genai.GenerativeModel(self.model)
-            response = model.generate_content(gemini_messages)
-            reply_text = response.text
-            self.sessions.session_reply(reply_text, session_id)
-            logger.info(f"[Gemini] reply={reply_text}")
-            return Reply(ReplyType.TEXT, reply_text)
+            
+            # 添加安全设置
+            safety_settings = {
+                HarmCategory.HARM_CATEGORY_HATE_SPEECH: HarmBlockThreshold.BLOCK_NONE,
+                HarmCategory.HARM_CATEGORY_HARASSMENT: HarmBlockThreshold.BLOCK_NONE,
+                HarmCategory.HARM_CATEGORY_SEXUALLY_EXPLICIT: HarmBlockThreshold.BLOCK_NONE,
+                HarmCategory.HARM_CATEGORY_DANGEROUS_CONTENT: HarmBlockThreshold.BLOCK_NONE,
+            }
+            
+            # 生成回复，包含安全设置
+            response = model.generate_content(
+                gemini_messages,
+                safety_settings=safety_settings
+            )
+            if response.candidates and response.candidates[0].content:
+                reply_text = response.candidates[0].content.parts[0].text
+                logger.info(f"[Gemini] reply={reply_text}")
+                self.sessions.session_reply(reply_text, session_id)
+                return Reply(ReplyType.TEXT, reply_text)
+            else:
+                # 没有有效响应内容，可能内容被屏蔽，输出安全评分
+                logger.warning("[Gemini] No valid response generated. Checking safety ratings.")
+                if hasattr(response, 'candidates') and response.candidates:
+                    for rating in response.candidates[0].safety_ratings:
+                        logger.warning(f"Safety rating: {rating.category} - {rating.probability}")
+                error_message = "No valid response generated due to safety constraints."
+                self.sessions.session_reply(error_message, session_id)
+                return Reply(ReplyType.ERROR, error_message)
+                    
         except Exception as e:
-            logger.error("[Gemini] fetch reply error, may contain unsafe content")
-            logger.error(e)
-            return Reply(ReplyType.ERROR, "invoke [Gemini] api failed!")
+            logger.error(f"[Gemini] Error generating response: {str(e)}", exc_info=True)
+            error_message = "Failed to invoke [Gemini] api!"
+            self.sessions.session_reply(error_message, session_id)
+            return Reply(ReplyType.ERROR, error_message)
 
     def _convert_to_gemini_messages(self, messages: list):
         res = []


### PR DESCRIPTION
The default security threshold for Gemini is too high, causing the generated text to be frequently blocked. I referred to Google's documentation and lowered the threshold for all four types of security settings.